### PR TITLE
fixed: `Module not found: Default condition should be last one`

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,14 +11,14 @@
     },
     "./node": {
       "default": {
-        "default": "./dist/cjs/index.js",
-        "types": "./dist/cjs/index.d.ts"
+        "types": "./dist/cjs/index.d.ts",
+        "default": "./dist/cjs/index.js"
       }
     },
     ".": {
       "default": {
-        "default": "./dist/workers/index.js",
-        "types": "./dist/workers/index.d.ts"
+        "types": "./dist/workers/index.d.ts",
+        "default": "./dist/workers/index.js"
       }
     }
   },

--- a/src/workers/index.ts
+++ b/src/workers/index.ts
@@ -1,5 +1,5 @@
 import LibImage from './libImage.js';
-import WASM from '../esm/libImage.wasm';
+import WASM from '../esm/libImage.wasm?module';
 
 const libImage = LibImage({
   instantiateWasm: async (imports, receiver) => {

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -2,3 +2,8 @@ declare module '*.wasm' {
   const content: never;
   export default content;
 }
+
+declare module '*.wasm?module' {
+  const content: never;
+  export default content;
+}


### PR DESCRIPTION
Fixed an error occuring in next.js edge runtime `Module not found: Default condition should be last one`

Since Cloudflare workers and Next.js can resolve *.wasm?module, we can import libImage.wasm?module in order to make it work on Next.js